### PR TITLE
Update token refresh cookie name

### DIFF
--- a/app/api/auth/token/route.ts
+++ b/app/api/auth/token/route.ts
@@ -4,9 +4,13 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(request:NextRequest) {
 
   const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("vcrm_access_token")?.value;
+  const refreshToken = cookieStore.get("vcrm_refresh_token")?.value;
 
-  console.log("TOKEN API received refresh token:", request.cookies.get("vcrm_access_token"),refreshToken);
+  console.log(
+    "TOKEN API received refresh token:",
+    request.cookies.get("vcrm_refresh_token"),
+    refreshToken
+  );
 
   if (!refreshToken) {
     return new NextResponse("Not authenticated", { status: 401 });


### PR DESCRIPTION
## Summary
- update token refresh cookie name to `vcrm_refresh_token`
- adjust console logging for the new cookie

## Testing
- `pnpm lint`
- `pnpm build` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*